### PR TITLE
.ovpn parsing errors

### DIFF
--- a/Passepartout-iOS/Info.plist
+++ b/Passepartout-iOS/Info.plist
@@ -42,7 +42,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<true/>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Passepartout/Sources/VPN/TunnelKitProvider+FileConfiguration.swift
+++ b/Passepartout/Sources/VPN/TunnelKitProvider+FileConfiguration.swift
@@ -31,31 +31,31 @@ private let log = SwiftyBeaver.self
 
 extension TunnelKitProvider.Configuration {
     private struct Regex {
-        static let proto = Utils.regex("proto +(udp6?|tcp6?)")
+        static let proto = Utils.regex("^proto +(udp6?|tcp6?)")
 
-        static let port = Utils.regex("port +\\d+")
+        static let port = Utils.regex("^port +\\d+")
         
-        static let remote = Utils.regex("remote +[^ ]+( +\\d+)?( +(udp6?|tcp6?))?")
+        static let remote = Utils.regex("^remote +[^ ]+( +\\d+)?( +(udp6?|tcp6?))?")
 
-        static let cipher = Utils.regex("cipher +[\\w\\-]+")
+        static let cipher = Utils.regex("^cipher +[\\w\\-]+")
 
-        static let auth = Utils.regex("auth +[\\w\\-]+")
+        static let auth = Utils.regex("^auth +[\\w\\-]+")
         
-        static let compLZO = Utils.regex("comp-lzo")
+        static let compLZO = Utils.regex("^comp-lzo")
 
-        static let compress = Utils.regex("compress")
+        static let compress = Utils.regex("^compress")
         
-        static let ping = Utils.regex("ping +\\d+")
+        static let ping = Utils.regex("^ping +\\d+")
 
-        static let renegSec = Utils.regex("reneg-sec +\\d+")
+        static let renegSec = Utils.regex("^reneg-sec +\\d+")
 
-        static let fragment = Utils.regex("fragment +\\d+")
+        static let fragment = Utils.regex("^fragment +\\d+")
 
-        static let keyDirection = Utils.regex("key-direction +\\d")
+        static let keyDirection = Utils.regex("^key-direction +\\d")
         
-        static let blockBegin = Utils.regex("<[\\w\\-]+>")
+        static let blockBegin = Utils.regex("^<[\\w\\-]+>")
         
-        static let blockEnd = Utils.regex("<\\/[\\w\\-]+>")
+        static let blockEnd = Utils.regex("^<\\/[\\w\\-]+>")
     }
     
     static func parsed(from url: URL) throws -> (String, TunnelKitProvider.Configuration) {


### PR DESCRIPTION
- Regex were not matching beginning of line (e.g. `cipher` was matching `tls-cipher` too).
- Copy document vs in-place, overcomes a permissions error with Apple Files.