### PR TITLE
Integrate TLS wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for TLS wrapping (tls-auth and tls-crypt). [#5](https://github.com/keeshux/passepartout-ios/pull/5)
+
 ### Fixed
 
-- Credentials are now optional for host profiles. [#4](https://github.com/keeshux/passepartout-ios/pull/4)
 - Fixed Mullvad abrupt disconnection. [tunnelkit#30](https://github.com/keeshux/tunnelkit/issues/30)
+- Credentials are now optional for host profiles. [#4](https://github.com/keeshux/passepartout-ios/pull/4)
 
 ## 1.0 beta 1018 (2018-10-18)
 

--- a/Passepartout-iOS/Scenes/ConfigurationViewController.swift
+++ b/Passepartout-iOS/Scenes/ConfigurationViewController.swift
@@ -195,7 +195,17 @@ extension ConfigurationViewController: UITableViewDataSource, UITableViewDelegat
         case .tlsWrapping:
             cell.leftText = L10n.Configuration.Cells.TlsWrapping.caption
             let V = L10n.Configuration.Cells.TlsWrapping.Value.self
-            cell.rightText = V.disabled
+            if let strategy = configuration.tlsWrap?.strategy {
+                switch strategy {
+                case .auth:
+                    cell.rightText = V.auth
+
+                case .crypt:
+                    cell.rightText = V.crypt
+                }
+            } else {
+                cell.rightText = V.disabled
+            }
             cell.accessoryType = .none
             cell.isTappable = false
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def shared_pods
     #pod 'TunnelKit', '~> 1.1.2'
-    pod 'TunnelKit', :git => 'https://github.com/keeshux/tunnelkit', :commit => 'ca192e4'
+    pod 'TunnelKit', :git => 'https://github.com/keeshux/tunnelkit', :commit => '29ec39f'
     #pod 'TunnelKit', :path => '../tunnelkit'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - MBProgressHUD (1.1.0)
   - OpenSSL-Apple (1.1.0i-v2)
   - SwiftyBeaver (1.6.1)
-  - TunnelKit (1.1.2):
-    - TunnelKit/AppExtension (= 1.1.2)
-    - TunnelKit/Core (= 1.1.2)
-  - TunnelKit/AppExtension (1.1.2):
+  - TunnelKit (1.2.0):
+    - TunnelKit/AppExtension (= 1.2.0)
+    - TunnelKit/Core (= 1.2.0)
+  - TunnelKit/AppExtension (1.2.0):
     - SwiftyBeaver
     - TunnelKit/Core
-  - TunnelKit/Core (1.1.2):
+  - TunnelKit/Core (1.2.0):
     - OpenSSL-Apple (~> 1.1.0h)
     - SwiftyBeaver
 
 DEPENDENCIES:
   - MBProgressHUD
-  - TunnelKit (from `https://github.com/keeshux/tunnelkit`, commit `ca192e4`)
+  - TunnelKit (from `https://github.com/keeshux/tunnelkit`, commit `29ec39f`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -24,20 +24,20 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   TunnelKit:
-    :commit: ca192e4
+    :commit: 29ec39f
     :git: https://github.com/keeshux/tunnelkit
 
 CHECKOUT OPTIONS:
   TunnelKit:
-    :commit: ca192e4
+    :commit: 29ec39f
     :git: https://github.com/keeshux/tunnelkit
 
 SPEC CHECKSUMS:
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
   OpenSSL-Apple: a93b8f2eec8783ff40d9a9304de180ab68bb647c
   SwiftyBeaver: ccfcdf85a04d429f1633f668650b0ce8020bda3a
-  TunnelKit: 8167e45290d15e2c7c789d8d4c0d5f084f532335
+  TunnelKit: aad1982c96ba0eace1494d4020ecdd1a34c5a788
 
-PODFILE CHECKSUM: a720594d8829c15b76e9ea32e2bd98a4854961cf
+PODFILE CHECKSUM: 3d7c4db47830b499bdcf24c498e36b5c619e2ad1
 
 COCOAPODS: 1.6.0.beta.2

--- a/README.md
+++ b/README.md
@@ -67,11 +67,8 @@ In preset mode, you can pick pre-resolved IPv4 endpoints when DNS is problematic
 
 Passepartout can import .ovpn configuration files. This way you can fine-tune encryption without tweaking and reimporting a new configuration. Below are a few limitations worth mentioning.
 
-Unsupported (yet):
+Unsupported:
 
-- TLS wrapping
-    - `--tls-auth`
-    - `--tls-crypt`
 - UDP fragmentation, i.e. `--fragment`
 
 Unsupported (probably ever):


### PR DESCRIPTION
After merging the following PRs:

- keeshux/tunnelkit#34
- keeshux/tunnelkit#35

the app can now support both `tls-auth` and `tls-crypt` wrapping. This PR integrates the feature into the UI.