### PR TITLE
Incorrect compression warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Incorrect compression warnings when importing host configurations. [#20](https://github.com/keeshux/passepartout-ios/pull/20)
+
 ## 1.0 RC1 1194 (2018-11-01)
 
 ### Added

--- a/Passepartout/Sources/Model/ConnectionService+Migration.swift
+++ b/Passepartout/Sources/Model/ConnectionService+Migration.swift
@@ -29,7 +29,7 @@ import SwiftyBeaver
 private let log = SwiftyBeaver.self
 
 extension ConnectionService {
-    static func migrateJSON(at from: URL, to: URL) {
+    static func migrateJSON(from: URL, to: URL) {
         do {
             let newData = try migrateJSON(at: from)
 //            log.verbose(String(data: newData, encoding: .utf8)!)
@@ -39,8 +39,8 @@ extension ConnectionService {
         }
     }
     
-    private static func migrateJSON(at from: URL) throws -> Data {
-        let data = try Data(contentsOf: from)
+    static func migrateJSON(at url: URL) throws -> Data {
+        let data = try Data(contentsOf: url)
         guard var json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             throw ApplicationError.migration
         }

--- a/Passepartout/Sources/Model/TransientStore.swift
+++ b/Passepartout/Sources/Model/TransientStore.swift
@@ -53,7 +53,7 @@ class TransientStore {
     private init() {
         let cfg = AppConstants.VPN.baseConfiguration()
         do {
-            ConnectionService.migrateJSON(at: TransientStore.serviceURL, to: TransientStore.serviceURL)
+            ConnectionService.migrateJSON(from: TransientStore.serviceURL, to: TransientStore.serviceURL)
             
             let data = try Data(contentsOf: TransientStore.serviceURL)
             if let content = String(data: data, encoding: .utf8) {

--- a/Passepartout/Sources/VPN/TunnelKitProvider+FileConfiguration.swift
+++ b/Passepartout/Sources/VPN/TunnelKitProvider+FileConfiguration.swift
@@ -53,9 +53,9 @@ extension TunnelKitProvider.Configuration {
 
         static let auth = Utils.regex("^auth +[\\w\\-]+")
         
-        static let compLZO = Utils.regex("^comp-lzo")
+        static let compLZO = Utils.regex("^comp-lzo.*")
 
-        static let compress = Utils.regex("^compress")
+        static let compress = Utils.regex("^compress.*")
         
         static let ping = Utils.regex("^ping +\\d+")
 


### PR DESCRIPTION
Regex patterns for `comp-lzo` and `compress` do not include arguments, thus leading to:

- *Always* showing a warning when a line starts with `comp-lzo`
- *Never* showing a warning when a line starts with `compress`

Extend the patterns to include optional arguments.